### PR TITLE
use method="html", fixes display issues with anchors

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,7 @@ Changelog
 
 * Don't de-float Wordpress smileys [miohtama]
 
-* 
+* Use method="html" in tostring() call, fixes display issues [reinhardt]
 
 0.9.2 - 1.0.0
 -------------------

--- a/mobile/htmlprocessing/tests/test_img.py
+++ b/mobile/htmlprocessing/tests/test_img.py
@@ -19,18 +19,24 @@ class ImageTestCase(unittest.TestCase):
         
         html = '<img src="http://www.foobar.com">'
         output = fix_html(html)        
-        self.assertEqual(output, '<img src="http://www.foobar.com" alt=""/>', "Got:" + output)
+        self.assertEqual(output, '<img src="http://www.foobar.com" alt="">', "Got:" + output)
                 
     def test_no_modify_existing_alt(self):
         """ Check that existing ALT attribute stays untouched """
         html = '<img src="http://www.foobar.com" alt="bar">'
         output = fix_html(html)        
-        self.assertEqual(output, '<img src="http://www.foobar.com" alt="bar"/>', "Got:" + output)
+        self.assertEqual(output, '<img src="http://www.foobar.com" alt="bar">', "Got:" + output)
         
     def test_no_modify_existing_alt_caps(self):
         html = '<img src="http://www.foobar.com" ALT="bar">'
         output = fix_html(html)        
-        self.assertEqual(output, '<img src="http://www.foobar.com" alt="bar"/>', "Got:" + output)
+        self.assertEqual(output, '<img src="http://www.foobar.com" alt="bar">', "Got:" + output)
+
+    def test_no_modify_anchor(self):
+        """An <a> tag before an <img> is not modified."""
+        html = '<a name="anchor"></a><img src="http://www.foobar.com" alt="bar">'
+        output = fix_html(html)
+        self.assertIn('<a name="anchor"></a>', output, "Got:" + output)
 
 
 def test_suite():    

--- a/mobile/htmlprocessing/tests/test_resize.py
+++ b/mobile/htmlprocessing/tests/test_resize.py
@@ -35,7 +35,7 @@ class ResizerTestCase(unittest.TestCase):
         
         html = '<img src="http://www.foobar.com">'
         output = self.transform(html)        
-        self.assertEqual(output, '<img src="http://localhost/@@resizer?url=http%3A%2F%2Fwww.foobar.com" alt="" style="float: none" class="mobile-resized"/>', "Got:" + output)
+        self.assertEqual(output, '<img src="http://localhost/@@resizer?url=http%3A%2F%2Fwww.foobar.com" alt="" style="float: none" class="mobile-resized">', "Got:" + output)
                 
     def test_alt(self):
         """ Check that existing ALT attribute stays untouched """
@@ -60,13 +60,13 @@ class ResizerTestCase(unittest.TestCase):
         self.assertTrue('float: none' in output, "Got:" + output)
         
     def test_process_existing_float_multi_style(self):
-        html = '<img src="http://www.foobar.com" style="float: left; border: 1px solid black" ALT="asdasdbar" />'
+        html = '<img src="http://www.foobar.com" style="float: left; border: 1px solid black" ALT="asdasdbar" >'
         output = self.transform(html)        
         self.assertTrue('solid black' in output, "Got:" + output)
         self.assertFalse('left' in output, "Got:" + output)
 
     def test_process_existing_float_hyper_multi_style(self):
-        html = '<img src="http://www.foobar.com" style="display: none; float: left; border: 1px solid black" ALT="asdasdbar" />'
+        html = '<img src="http://www.foobar.com" style="display: none; float: left; border: 1px solid black" ALT="asdasdbar" >'
         output = self.transform(html)        
         self.assertTrue('solid black' in output, "Got:" + output)
         self.assertFalse('left' in output, "Got:" + output)

--- a/mobile/htmlprocessing/transformers/basic.py
+++ b/mobile/htmlprocessing/transformers/basic.py
@@ -100,7 +100,7 @@ if LXML:
             if not self.trusted:
                 self(doc)
     
-            return tostring(doc, method="xml", encoding='UTF-8')
+            return tostring(doc, method="html", encoding='UTF-8')
 
 else:
     # No LXML


### PR DESCRIPTION
I have experienced display issues when using the gomobile.mobile package in Plone 4. They were caused by anchors being modified from having an explicit end tag to a slash terminated single tag, i.e. from something like

<a name="anchor"></a>

to

<a name="anchor" />

The test test_no_modify_anchor demonstrates this issue.

Changing method="xml" to method="html" in the lxml tostring() call fixes it. I propose to change this, except of course there is a reason why method="xml" is necessary.
